### PR TITLE
use newer version of MooX::Role::Parameterized

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -72,6 +72,9 @@ max_target_perl = 5.010
 [AutoPrereqs]       ; find prereqs from code
 # skip = ^This::Module$
  
+[Prereqs]
+MooX::Role::Parameterized = 0.300
+
 [MinimumPerl]       ; determine minimum perl version
  
 [MetaNoIndex]       ; sets 'no_index' in META

--- a/lib/MarpaX/Role/Parameterized/ResourceIdentifier/BNF.pm
+++ b/lib/MarpaX/Role/Parameterized/ResourceIdentifier/BNF.pm
@@ -439,7 +439,7 @@ role {
     #
     # An extension must provide 'can_scheme'
     #
-    $mop->requires('can_scheme');
+    requires 'can_scheme'; # conside use of $mop->require('can_scheme');
   }
   #
   # Keep track of installed methods

--- a/lib/MarpaX/Role/Parameterized/ResourceIdentifier/BNF.pm
+++ b/lib/MarpaX/Role/Parameterized/ResourceIdentifier/BNF.pm
@@ -375,7 +375,7 @@ sub BUILD {
 # =============================================================================
 # Parameter validation
 # =============================================================================
-our $check_params = compile(
+our $check_params = compile( # consider use parameters, featured added on MooX::R::P 0.500
                             slurpy
                             Dict[
                                  whoami      => Str,
@@ -448,7 +448,8 @@ role {
   #
   # Make sure $whoami package is doing MooX::Role::Logger is not already
   #
-  Role::Tiny->apply_roles_to_package($whoami, 'MooX::Role::Logger') unless $whoami->DOES('MooX::Role::Logger');
+  Role::Tiny->apply_roles_to_package($whoami, 'MooX::Role::Logger') # consider use of $mop->with('MooX::Role::Logger')
+    unless $whoami->DOES('MooX::Role::Logger');
   my $action_full_name = sprintf('%s::_action', $whoami);
   #
   # Push on-the-fly the action name

--- a/lib/MarpaX/Role/Parameterized/ResourceIdentifier/BNF.pm
+++ b/lib/MarpaX/Role/Parameterized/ResourceIdentifier/BNF.pm
@@ -407,6 +407,7 @@ my %context = ();
 
 role {
   my $params = shift;
+  my $mop    = shift;
   #
   # -----------------------
   # Sanity checks on params
@@ -438,7 +439,7 @@ role {
     #
     # An extension must provide 'can_scheme'
     #
-    requires 'can_scheme';
+    $mop->requires('can_scheme');
   }
   #
   # Keep track of installed methods


### PR DESCRIPTION
Hello

the role block inside the parametric role can accept a mop object to inject methods, fields and require other roles.

is it possible change the code to use the $mop however, it is not clear for me how do you apply the parametric role. I did not understand you code and I don't want to break things.

consider review the actual documentation, if you need any help please let me known

fix issue #1 
